### PR TITLE
PUB-4380, Change import path to LiveRamp

### DIFF
--- a/curatorext/watched_map.go
+++ b/curatorext/watched_map.go
@@ -5,7 +5,7 @@ import (
 	"github.com/curator-go/curator"
 	"github.com/curator-go/curator/recipes/cache"
 	"path"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 type Loader func(ctx *thriftext.ThreadCtx, client curator.CuratorFramework, listener thriftext.DataChangeNotifier, path string) (interface{}, error)

--- a/curatorext/watched_map_test.go
+++ b/curatorext/watched_map_test.go
@@ -1,13 +1,13 @@
 package curatorext
 
 import (
-	"github.com/liveramp/hank-go-client/fixtures"
+	"github.com/LiveRamp/hank-go-client/fixtures"
 	"time"
 	"path"
 	"reflect"
 	"github.com/curator-go/curator"
 	"testing"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 func LoadString(ctx *thriftext.ThreadCtx, client curator.CuratorFramework, listener thriftext.DataChangeNotifier, path string) (interface{}, error) {

--- a/curatorext/watched_node.go
+++ b/curatorext/watched_node.go
@@ -8,7 +8,7 @@ import (
 	"github.com/curator-go/curator/recipes/cache"
 	"github.com/samuel/go-zookeeper/zk"
 	"time"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 type Constructor func() interface{}

--- a/curatorext/watched_node_test.go
+++ b/curatorext/watched_node_test.go
@@ -2,13 +2,13 @@ package curatorext
 
 import (
 	"reflect"
-	"github.com/liveramp/hank-go-client/fixtures"
+	"github.com/LiveRamp/hank-go-client/fixtures"
 	"github.com/curator-go/curator"
 	"fmt"
 	"time"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 func TestZkWatchedNode(t *testing.T) {

--- a/curatorext/watched_nodes.go
+++ b/curatorext/watched_nodes.go
@@ -4,7 +4,7 @@ import (
 	"git.apache.org/thrift.git/lib/go/thrift"
 	"github.com/curator-go/curator"
 	"strconv"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 //  thrift

--- a/curatorext/zk_tools_test.go
+++ b/curatorext/zk_tools_test.go
@@ -1,7 +1,7 @@
 package curatorext
 
 import (
-	"github.com/liveramp/hank-go-client/fixtures"
+	"github.com/LiveRamp/hank-go-client/fixtures"
 	"github.com/samuel/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/curatorext/zk_utils.go
+++ b/curatorext/zk_utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cenkalti/backoff"
 	"time"
 	"fmt"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 224175b3e854ea42c41d9b5b4f80112b45eb71a3cef7924cde72118056ca7231
-updated: 2017-07-07T09:58:14.59621061-07:00
+hash: 16c5c11448f7c1ebe39a94f3342d5a3912fcfd35142b501a6ff34d1406acd91c
+updated: 2017-10-24T19:16:51.956257732-04:00
 imports:
 - name: git.apache.org/thrift.git
   version: e41e47c2b4b2407bac525d203b281c63fb253978
@@ -23,7 +23,7 @@ imports:
   version: 0a025b7e63adc15a622f29b0b2c4c3848243bbf6
 - name: github.com/karlseguin/ccache
   version: a2d62155777b39595c825ed3824279e642a5db3c
-- name: github.com/liveramp/hank
+- name: github.com/LiveRamp/hank
   version: 02714809b158733750feab238985b1713b7b22e1
   subpackages:
   - hank-core/src/main/go/hank

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: .
+package: github.com/LiveRamp/hank-go-client
 import:
 - package: git.apache.org/thrift.git
   subpackages:
@@ -40,6 +40,6 @@ import:
   version: ~1.1.0
 - package: github.com/karlseguin/ccache
   version: ^2.0.2
-- package: github.com/liveramp/hank
+- package: github.com/LiveRamp/hank
   subpackages:
   - hank-core/src/main/go/hank

--- a/hank_client/host_connection.go
+++ b/hank_client/host_connection.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/liveramp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/iface"
 	"time"
-	"github.com/liveramp/hank-go-client/syncext"
-	"github.com/liveramp/hank/hank-core/src/main/go/hank"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/syncext"
+	"github.com/LiveRamp/hank/hank-core/src/main/go/hank"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 type HostConnection struct {

--- a/hank_client/host_connection_pool.go
+++ b/hank_client/host_connection_pool.go
@@ -4,12 +4,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/liveramp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/iface"
 	"math/rand"
 	"sort"
 	"sync"
 	"time"
-	"github.com/liveramp/hank/hank-core/src/main/go/hank"
+	"github.com/LiveRamp/hank/hank-core/src/main/go/hank"
 )
 
 const NO_HASH = -1

--- a/hank_client/host_connection_pool_test.go
+++ b/hank_client/host_connection_pool_test.go
@@ -2,15 +2,15 @@ package hank_client
 
 import (
 	"fmt"
-	"github.com/liveramp/hank-go-client/fixtures"
-	"github.com/liveramp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/fixtures"
+	"github.com/LiveRamp/hank-go-client/iface"
 	"github.com/curator-go/curator"
 	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
-	"github.com/liveramp/hank-go-client/zk_coordinator"
-	"github.com/liveramp/hank/hank-core/src/main/go/hank"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/zk_coordinator"
+	"github.com/LiveRamp/hank/hank-core/src/main/go/hank"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 func Exception() *hank.HankResponse {

--- a/hank_client/host_connection_test.go
+++ b/hank_client/host_connection_test.go
@@ -3,16 +3,16 @@ package hank_client
 import (
 	"fmt"
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/liveramp/hank-go-client/fixtures"
-	"github.com/liveramp/hank-go-client/iface"
-	"github.com/liveramp/hank-go-client/thrift_services"
+	"github.com/LiveRamp/hank-go-client/fixtures"
+	"github.com/LiveRamp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/thrift_services"
 	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 	"time"
-	"github.com/liveramp/hank-go-client/zk_coordinator"
-	"github.com/liveramp/hank/hank-core/src/main/go/hank"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/zk_coordinator"
+	"github.com/LiveRamp/hank/hank-core/src/main/go/hank"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 func TestQueryWhenServing(t *testing.T) {

--- a/hank_client/smart_client.go
+++ b/hank_client/smart_client.go
@@ -3,16 +3,16 @@ package hank_client
 import (
 	"errors"
 	"fmt"
-	"github.com/liveramp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/iface"
 	"math"
 	"os"
 	"strconv"
 	"sync"
 	"time"
 	"github.com/karlseguin/ccache"
-	"github.com/liveramp/hank-go-client/syncext"
-	"github.com/liveramp/hank/hank-core/src/main/go/hank"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/syncext"
+	"github.com/LiveRamp/hank/hank-core/src/main/go/hank"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 const NUM_STAT_SAMPLES = 3

--- a/hank_client/smart_client_test.go
+++ b/hank_client/smart_client_test.go
@@ -2,15 +2,15 @@ package hank_client
 
 import (
 	"fmt"
-	"github.com/liveramp/hank-go-client/fixtures"
-	"github.com/liveramp/hank-go-client/iface"
-	"github.com/liveramp/hank-go-client/thrift_services"
+	"github.com/LiveRamp/hank-go-client/fixtures"
+	"github.com/LiveRamp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/thrift_services"
 	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 	"time"
-	"github.com/liveramp/hank-go-client/zk_coordinator"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/zk_coordinator"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 func TestSmartClient(t *testing.T) {

--- a/hank_client/test_fixtures.go
+++ b/hank_client/test_fixtures.go
@@ -2,15 +2,15 @@ package hank_client
 
 import (
 	"github.com/curator-go/curator"
-	"github.com/liveramp/hank-go-client/iface"
-	"github.com/liveramp/hank-go-client/thrift_services"
+	"github.com/LiveRamp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/thrift_services"
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/liveramp/hank-go-client/fixtures"
+	"github.com/LiveRamp/hank-go-client/fixtures"
 	"testing"
 	"strconv"
-	"github.com/liveramp/hank-go-client/zk_coordinator"
-	"github.com/liveramp/hank/hank-core/src/main/go/hank"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/zk_coordinator"
+	"github.com/LiveRamp/hank/hank-core/src/main/go/hank"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 func createHostServer(t *testing.T, ctx *thriftext.ThreadCtx, client curator.CuratorFramework, i int, server hank.PartitionServer) (iface.Host, func()) {

--- a/iface/cast.go
+++ b/iface/cast.go
@@ -1,6 +1,6 @@
 package iface
 
-import "github.com/liveramp/hank/hank-core/src/main/go/hank"
+import "github.com/LiveRamp/hank/hank-core/src/main/go/hank"
 
 func AsDomain(val interface{}) Domain {
 	if val == nil {

--- a/iface/ifaces.go
+++ b/iface/ifaces.go
@@ -2,8 +2,8 @@ package iface
 
 import (
 	"strconv"
-	"github.com/liveramp/hank/hank-core/src/main/go/hank"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank/hank-core/src/main/go/hank"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 /*

--- a/main/connect_script.go
+++ b/main/connect_script.go
@@ -5,8 +5,8 @@ import (
 	"github.com/curator-go/curator"
 	"os"
 	"time"
-	"github.com/liveramp/hank-go-client/zk_coordinator"
-	"github.com/liveramp/hank-go-client/hank_client"
+	"github.com/LiveRamp/hank-go-client/zk_coordinator"
+	"github.com/LiveRamp/hank-go-client/hank_client"
 )
 
 func main() {

--- a/main/simple_query_script.go
+++ b/main/simple_query_script.go
@@ -4,14 +4,14 @@ import (
 	"bufio"
 	"encoding/hex"
 	"fmt"
-	"github.com/liveramp/hank-go-client/iface"
-	"github.com/liveramp/hank-go-client/zk_coordinator"
+	"github.com/LiveRamp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/zk_coordinator"
 	"github.com/curator-go/curator"
 	"log"
 	"os"
 	"strings"
 	"time"
-	"github.com/liveramp/hank-go-client/hank_client"
+	"github.com/LiveRamp/hank-go-client/hank_client"
 )
 
 func main() {

--- a/syncext/single_lock_semaphore_test.go
+++ b/syncext/single_lock_semaphore_test.go
@@ -3,7 +3,7 @@ package syncext
 import (
 	"testing"
 	"github.com/stretchr/testify/assert"
-	"github.com/liveramp/hank-go-client/fixtures"
+	"github.com/LiveRamp/hank-go-client/fixtures"
 )
 
 func TestLock(t *testing.T) {

--- a/thrift_services/map_partition_server.go
+++ b/thrift_services/map_partition_server.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"git.apache.org/thrift.git/lib/go/thrift"
 	"sync"
-	"github.com/liveramp/hank/hank-core/src/main/go/hank"
+	"github.com/LiveRamp/hank/hank-core/src/main/go/hank"
 )
 
 type MapPartitionServerHandler struct {

--- a/thrift_services/map_partition_server_test.go
+++ b/thrift_services/map_partition_server_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
-	"github.com/liveramp/hank/hank-core/src/main/go/hank"
+	"github.com/LiveRamp/hank/hank-core/src/main/go/hank"
 )
 
 const PARTITION_SERVER_ADDRESS = "127.0.0.1:56783"

--- a/zk_coordinator/coordinator.go
+++ b/zk_coordinator/coordinator.go
@@ -3,9 +3,9 @@ package zk_coordinator
 import (
 	"github.com/curator-go/curator"
 	"path"
-	"github.com/liveramp/hank-go-client/iface"
-	"github.com/liveramp/hank-go-client/curatorext"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/curatorext"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 const KEY_DOMAIN_ID_COUNTER string = ".domain_id_counter"

--- a/zk_coordinator/coordinator_test.go
+++ b/zk_coordinator/coordinator_test.go
@@ -7,8 +7,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
-	"github.com/liveramp/hank-go-client/fixtures"
-	"github.com/liveramp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/fixtures"
+	"github.com/LiveRamp/hank-go-client/iface"
 )
 
 func TestZkCoordinator(t *testing.T) {

--- a/zk_coordinator/domain.go
+++ b/zk_coordinator/domain.go
@@ -3,11 +3,11 @@ package zk_coordinator
 import (
   "github.com/curator-go/curator"
   "path"
-  "github.com/liveramp/hank-go-client/iface"
+  "github.com/LiveRamp/hank-go-client/iface"
   "strings"
-  "github.com/liveramp/hank-go-client/curatorext"
-  "github.com/liveramp/hank/hank-core/src/main/go/hank"
-  "github.com/liveramp/hank-go-client/thriftext"
+  "github.com/LiveRamp/hank-go-client/curatorext"
+  "github.com/LiveRamp/hank/hank-core/src/main/go/hank"
+  "github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 type ZkDomain struct {

--- a/zk_coordinator/domain_group.go
+++ b/zk_coordinator/domain_group.go
@@ -3,10 +3,10 @@ package zk_coordinator
 import (
 	"github.com/curator-go/curator"
 	"path"
-	"github.com/liveramp/hank-go-client/iface"
-	"github.com/liveramp/hank-go-client/curatorext"
-	"github.com/liveramp/hank/hank-core/src/main/go/hank"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/curatorext"
+	"github.com/LiveRamp/hank/hank-core/src/main/go/hank"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 type ZkDomainGroup struct {

--- a/zk_coordinator/host.go
+++ b/zk_coordinator/host.go
@@ -4,14 +4,14 @@ import (
 	"github.com/curator-go/curator"
 	"path"
 	"strings"
-	"github.com/liveramp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/iface"
 	"fmt"
 	"github.com/satori/go.uuid"
 	"math/big"
 	"strconv"
-	"github.com/liveramp/hank-go-client/curatorext"
-	"github.com/liveramp/hank/hank-core/src/main/go/hank"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/curatorext"
+	"github.com/LiveRamp/hank/hank-core/src/main/go/hank"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 const ASSIGNMENTS_PATH string = "a"

--- a/zk_coordinator/host_domain.go
+++ b/zk_coordinator/host_domain.go
@@ -1,8 +1,8 @@
 package zk_coordinator
 
 import (
-	"github.com/liveramp/hank-go-client/iface"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 type ZkHostDomain struct {

--- a/zk_coordinator/host_domain_partition.go
+++ b/zk_coordinator/host_domain_partition.go
@@ -1,8 +1,8 @@
 package zk_coordinator
 
 import (
-  "github.com/liveramp/hank-go-client/iface"
-  "github.com/liveramp/hank-go-client/thriftext"
+  "github.com/LiveRamp/hank-go-client/iface"
+  "github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 type ZkHostDomainPartition struct {

--- a/zk_coordinator/ring.go
+++ b/zk_coordinator/ring.go
@@ -2,13 +2,13 @@ package zk_coordinator
 
 import (
 	"fmt"
-	"github.com/liveramp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/iface"
 	"github.com/curator-go/curator"
 	"path"
 	"regexp"
 	"strconv"
-	"github.com/liveramp/hank-go-client/curatorext"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/curatorext"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 var RING_REGEX = regexp.MustCompile("ring-([0-9]+)")

--- a/zk_coordinator/ring_group.go
+++ b/zk_coordinator/ring_group.go
@@ -4,10 +4,10 @@ import (
 	"github.com/curator-go/curator"
 	"path"
 	"strconv"
-	"github.com/liveramp/hank-go-client/iface"
-	"github.com/liveramp/hank-go-client/curatorext"
-	"github.com/liveramp/hank/hank-core/src/main/go/hank"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/curatorext"
+	"github.com/LiveRamp/hank/hank-core/src/main/go/hank"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 const CLIENT_ROOT string = "c"

--- a/zk_coordinator/thrift_watch_node_test.go
+++ b/zk_coordinator/thrift_watch_node_test.go
@@ -1,13 +1,13 @@
 package zk_coordinator
 
 import (
-	"github.com/liveramp/hank-go-client/fixtures"
-	"github.com/liveramp/hank/hank-core/src/main/go/hank"
+	"github.com/LiveRamp/hank-go-client/fixtures"
+	"github.com/LiveRamp/hank/hank-core/src/main/go/hank"
 	"github.com/curator-go/curator"
-	"github.com/liveramp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/iface"
 	"testing"
-	"github.com/liveramp/hank-go-client/curatorext"
-	"github.com/liveramp/hank-go-client/thriftext"
+	"github.com/LiveRamp/hank-go-client/curatorext"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 //	TODO get some non-hank dummy thrift types and test this in the curatorext package


### PR DESCRIPTION
Adopting the import path prefix `github.com/LiveRamp/hank-go-client/` makes the import path consistent with the project URL.

The import changes were done in-place without any change in sorting to keep the diff easier to follow.

Naming the project in `glide.yaml` removes one of the glide warnings.