### PR TITLE
Lock map to prevent concurrent writes, plus cleanup

### DIFF
--- a/curatorext/watched_map.go
+++ b/curatorext/watched_map.go
@@ -51,7 +51,9 @@ func (p *ChildLoader) ChildEvent(client curator.CuratorFramework, event cache.Tr
 		}
 	case cache.TreeCacheEventNodeRemoved:
 		fullChildPath := event.Data.Path()
+		p.lock.Lock()
 		delete(p.internalData, path.Base(fullChildPath))
+		p.lock.Unlock()
 		p.listener.OnChange()
 	}
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,9 +13,6 @@ import:
 - package: github.com/stretchr/testify
   subpackages:
   - assert
-- package: go4.org
-  subpackages:
-  - syncutil/singleflight
 - package: golang.org/x/crypto
   subpackages:
   - acme/autocert

--- a/main/simple_query_script.go
+++ b/main/simple_query_script.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LiveRamp/hank-go-client/hank_client"
 	"github.com/LiveRamp/hank-go-client/iface"
 	"github.com/LiveRamp/hank-go-client/zk_coordinator"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 func main() {
@@ -22,7 +23,7 @@ func main() {
 	client := curator.NewClient(argsWithoutProg[0], curator.NewRetryNTimes(1, time.Second))
 	client.Start()
 
-	ctx := curatorext.NewThreadCtx()
+	ctx := thriftext.NewThreadCtx()
 
 	coordinator, coordErr := zk_coordinator.NewZkCoordinator(client, "/hank/domains", "/hank/ring_groups", "/hank/domain_groups")
 	if coordErr != nil {

--- a/zk_coordinator/coordinator_test.go
+++ b/zk_coordinator/coordinator_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/LiveRamp/hank-go-client/fixtures"
 	"github.com/LiveRamp/hank-go-client/iface"
+	"github.com/LiveRamp/hank-go-client/thriftext"
 )
 
 func TestZkCoordinator(t *testing.T) {
@@ -19,7 +20,7 @@ func TestZkCoordinator(t *testing.T) {
 	zkCoordinator, err1 := createCoordinator(client)
 	zkCoordinator3, err2 := createCoordinator(client)
 
-	ctx := curatorext.NewThreadCtx()
+	ctx := thriftext.NewThreadCtx()
 
 	if err1 != nil {
 		assert.Fail(t, "Error initializing coordinator 1")


### PR DESCRIPTION
Main change should prevent concurrent writes to map.  Also fixes a few broken imports. 