### PR TITLE
implement java partitioner so partitions match

### DIFF
--- a/hank_client/host_connection_pool.go
+++ b/hank_client/host_connection_pool.go
@@ -145,7 +145,7 @@ func buildConnections(connectionsByHost map[string][]*HostConnection, hostIndex 
 
 }
 
-func (p *HostConnectionPool) getConnectionFromPools(pools *ConnectionSet, keyHash int64, connection *IndexedHostConnection) (*IndexedHostConnection, bool) {
+func (p *HostConnectionPool) getConnectionFromPools(pools *ConnectionSet, keyHash int32, connection *IndexedHostConnection) (*IndexedHostConnection, bool) {
 
 	var conn *IndexedHostConnection
 	var locked bool
@@ -167,8 +167,8 @@ func (p *HostConnectionPool) getConnectionFromPools(pools *ConnectionSet, keyHas
 
 }
 
-func (p *HostConnectionPool) getConnectionToUseForKey(pool *ConnectionSet, keyHash int64) (*IndexedHostConnection, bool) {
-	return p.getNextConnectionToUse(int32(keyHash%int64(len(pool.connections))), pool.connections)
+func (p *HostConnectionPool) getConnectionToUseForKey(pool *ConnectionSet, keyHash int32) (*IndexedHostConnection, bool) {
+	return p.getNextConnectionToUse(int32(keyHash%int32(len(pool.connections))), pool.connections)
 }
 
 func (p *HostConnectionPool) getNextHostIndexToUse(previouslyUsedHostIndex int32, connections [][]*IndexedHostConnection) int32 {
@@ -332,7 +332,7 @@ func (p *HostConnectionPool) attemptQuery(connection *IndexedHostConnection, isL
 	}
 }
 
-func (p *HostConnectionPool) Get(domain iface.Domain, key []byte, maxNumTries int32, keyHash int64) *hank.HankResponse {
+func (p *HostConnectionPool) Get(domain iface.Domain, key []byte, maxNumTries int32, keyHash int32) *hank.HankResponse {
 
 	var indexedConnection *IndexedHostConnection
 	var locked bool

--- a/hank_client/host_connection_pool_test.go
+++ b/hank_client/host_connection_pool_test.go
@@ -448,7 +448,7 @@ func TestConsistentHashing(t *testing.T) {
 			host2.GetAddress().Print(),
 		})
 
-		keyHash := int64(42)
+		keyHash := int32(42)
 
 		for j := 0; j < 10; j++ {
 

--- a/iface/ifaces.go
+++ b/iface/ifaces.go
@@ -102,7 +102,7 @@ type Host interface {
 }
 
 type Partitioner interface {
-	Partition(key []byte, numPartitions int32) int64
+	Partition(key []byte, numPartitions int32) int32
 }
 
 type Domain interface {

--- a/zk_coordinator/partitioner.go
+++ b/zk_coordinator/partitioner.go
@@ -1,20 +1,95 @@
 package zk_coordinator
 
-import (
-	"github.com/aviddiviner/go-murmur"
-)
-
 type Murmur64Partitioner struct{}
 
 const SEED = 645568
+const M = int64(-4132994306676758123)
 
-func abs64(val int64) int64 {
-	if val < 0 {
-		return -val
-	}
-	return val
+func (p *Murmur64Partitioner) Partition(key []byte, numPartitions int32) int32 {
+	return abs(int32(MurmurHash64(key, SEED)) % int32(numPartitions))
 }
 
-func (p *Murmur64Partitioner) Partition(key []byte, numPartitions int32) int64 {
-	return abs64(int64(murmur.MurmurHash64A(key, SEED)) % int64(numPartitions))
+func abs(partition int32) int32{
+
+	if partition < 0 {
+		return -partition
+	}
+	return partition
+
+}
+
+//	this is probably * wrong * in a technical sense, but it matches Hank's Java implementation (hopefully)
+func MurmurHash64(data []byte, seed int) (h int64) {
+
+	r := 47
+
+	len := len(data)
+	hTemp := int64(uint64(seed) ^ uint64(int(len) * int(M)))
+
+	remainder := len & 7
+
+	end := len - remainder
+
+	for i := 0; i < end; i += 8 {
+
+		k := int64(int8(data[i+7]))
+		k = k << 8
+
+		k = int64(k | int64(int64(int8(data[i+6]))&0xff))
+		k = k << 8
+
+		k = int64(k | int64(int64(int8(data[i+5]))&0xff))
+		k = k << 8
+
+		k = int64(k | int64(int64(int8(data[i+4]))&0xff))
+		k = k << 8
+
+		k = int64(k | int64(int64(int8(data[i+3]))&0xff))
+		k = k << 8
+
+		k = int64(k | int64(int64(int8(data[i+2]))&0xff))
+		k = k << 8
+
+		k = int64(k | int64(int64(int8(data[i+1]))&0xff))
+		k = k << 8
+
+		k = int64(k | int64(int64(int8(data[i+0]))&0xff))
+		k = k * M
+		k = k ^ int64(uint64(k)>>uint64(r))
+		k = k * M
+
+		hTemp  = int64(uint64(hTemp) ^ uint64(k))
+
+		hTemp = M * hTemp
+	}
+
+	switch remainder {
+	case 7:
+		hTemp = int64(uint64(hTemp) ^ uint64(uint64(uint8(data[end+6]) & uint8(0xff)) << uint(48)))
+		fallthrough
+	case 6:
+		hTemp = int64(uint64(hTemp) ^ uint64(int64(uint64(uint8(data[end+5]) & uint8(0xff)) << uint(40))))
+		fallthrough
+	case 5:
+		hTemp = int64(uint64(hTemp) ^ uint64(int64(uint64(uint8(data[end+4]) & uint8(0xff)) << uint(32))))
+		fallthrough
+	case 4:
+		hTemp = int64(uint64(hTemp) ^ uint64(int64(uint64(uint8(data[end+3]) & uint8(0xff)) << uint(24))))
+		fallthrough
+	case 3:
+		hTemp = int64(uint64(hTemp) ^ uint64(int64(uint64(uint8(data[end+2]) & uint8(0xff)) << uint(16))))
+		fallthrough
+	case 2:
+		hTemp = int64(uint64(hTemp) ^ uint64(int64(uint64(uint8(data[end+1]) & uint8(0xff)) << uint(8))))
+		fallthrough
+	case 1:
+		hTemp = int64(uint64(hTemp) ^ uint64(int64(uint64(uint8(data[end]) & uint8(0xff)))))
+		hTemp = hTemp * M
+	}
+
+	hTemp = hTemp ^ int64(uint64(hTemp) >> uint(r))
+	hTemp = int64(hTemp) * M
+	hTemp = hTemp ^ int64(uint64(hTemp) >> uint64(r))
+
+	return int64(hTemp)
 }

--- a/zk_coordinator/partitioner_test.go
+++ b/zk_coordinator/partitioner_test.go
@@ -1,0 +1,43 @@
+package zk_coordinator
+
+import (
+	"testing"
+	"encoding/hex"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPartitioner(t *testing.T) {
+
+	partitioner := &Murmur64Partitioner{}
+	bytes, _ := hex.DecodeString("6760db3664815e8114622a615cf491f5837c60e23862fe97ef2fb72f05281d07")
+	partition := partitioner.Partition(bytes, 1024)
+	assert.Equal(t, int32(765), partition)
+
+	bytes = []byte("9q34poifj[9qvjafjqpfewajpf")
+	partition = partitioner.Partition(bytes, 1024)
+	assert.Equal(t, int32(1020), partition)
+
+	bytes = []byte("f304pf4ijq3f90[qpefjqfieoawfjaws")
+	partition = partitioner.Partition(bytes, 1024)
+	assert.Equal(t, int32(193), partition)
+
+}
+
+
+func TestMurmur64(t *testing.T) {
+
+	bytes, _ := hex.DecodeString("6760db3664815e8114622a615cf491f5837c60e23862fe97ef2fb72f05281d07")
+	assert.Equal(t, int64(6343921159570942211), MurmurHash64(bytes, 645568))
+
+	bytes = []byte("test12345")
+	assert.Equal(t, int64(-7808825886808697493), MurmurHash64(bytes, 645568))
+
+	bytes = []byte("934;wkfq3lfq")
+	assert.Equal(t, int64(1582694255121429424), MurmurHash64(bytes, 645568))
+
+	bytes = []byte("%#G%GVWC$WGDSSasdfaeaf4393q4u0ajerjeiaer")
+	assert.Equal(t, int64(1912501296182416924), MurmurHash64(bytes, 645568))
+
+	bytes = []byte("%#G%0[u8w34goijaviaevalkdscasdfjalks   ")
+	assert.Equal(t, int64(435888642032577352), MurmurHash64(bytes, 645568))
+}


### PR DESCRIPTION
The casting is an abomination and probably a lot of it can be removed, but I won't have time to clean it up much for the next week, so I'd rather let you run with it now.