### PR TITLE
cleanup logging and error returns

### DIFF
--- a/curatorext/watched_node.go
+++ b/curatorext/watched_node.go
@@ -55,7 +55,8 @@ func (p *ObjLoader) ChildEvent(client curator.CuratorFramework, event cache.Tree
 
 		obj, err := p.watchedNode.deserializer(p.watchedNode.ctx, data.Data(), p.watchedNode.constructor)
 		if err != nil {
-			log.WithField("child", event.Data.Path()).WithError(err).Error("Error loading watched node child")
+			//	log here because it's called by zk events and doesn't ever percolate up to the user
+			log.WithField("node_Added", event.Data.Path()).WithError(err).Error("error loading watched node child")
 			return err
 		}
 
@@ -69,7 +70,10 @@ func (p *ObjLoader) ChildEvent(client curator.CuratorFramework, event cache.Tree
 
 	if p.watchedNode.stat != nil && p.watchedNode.stat.Version != prevVersion {
 		for _, listener := range p.watchedNode.listeners {
-			listener.OnDataChange(p.watchedNode.value)
+			err := listener.OnDataChange(p.watchedNode.value)
+			if err != nil {
+				log.WithField("removed_path", event.Data.Path()).WithError(err).Error("error OnDataChange")
+			}
 		}
 	}
 

--- a/curatorext/watched_node.go
+++ b/curatorext/watched_node.go
@@ -56,7 +56,7 @@ func (p *ObjLoader) ChildEvent(client curator.CuratorFramework, event cache.Tree
 		obj, err := p.watchedNode.deserializer(p.watchedNode.ctx, data.Data(), p.watchedNode.constructor)
 		if err != nil {
 			//	log here because it's called by zk events and doesn't ever percolate up to the user
-			log.WithField("node_Added", event.Data.Path()).WithError(err).Error("error loading watched node child")
+			log.WithField("node_added", event.Data.Path()).WithError(err).Error("error loading watched node child")
 			return err
 		}
 

--- a/hank_client/host_connection.go
+++ b/hank_client/host_connection.go
@@ -9,8 +9,8 @@ import (
 	"github.com/LiveRamp/hank-go-client/iface"
 	"github.com/LiveRamp/hank-go-client/syncext"
 	"github.com/LiveRamp/hank-go-client/thriftext"
-	log "github.com/sirupsen/logrus"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 type HostConnection struct {

--- a/hank_client/host_connection_pool_test.go
+++ b/hank_client/host_connection_pool_test.go
@@ -367,8 +367,8 @@ func TestOneHanging(t *testing.T) {
 	previousIface1NumGets := 0
 
 	for i := 0; i < 10; i++ {
-		val := pool.Get(domain, Key1(), 1, NO_HASH)
-		if val.IsSetValue() {
+		val, _ := pool.Get(domain, Key1(), 1, NO_HASH)
+		if val != nil && val.IsSetValue() {
 			numHits++
 		}
 
@@ -394,7 +394,7 @@ func TestOneHanging(t *testing.T) {
 	numHits = 0
 
 	for i := 0; i < 10; i++ {
-		val := pool.Get(domain, Key1(), 2, NO_HASH)
+		val, _ := pool.Get(domain, Key1(), 2, NO_HASH)
 		if val.IsSetValue() {
 			numHits++
 		}
@@ -449,10 +449,10 @@ func TestConsistentHashing(t *testing.T) {
 
 		for j := 0; j < 10; j++ {
 
-			respA := poolA.Get(domain, []byte(Val1Str), 1, keyHash)
-			respB := poolB.Get(domain, []byte(Val1Str), 1, keyHash)
+			respA, _ := poolA.Get(domain, []byte(Val1Str), 1, keyHash)
+			respB, _ := poolB.Get(domain, []byte(Val1Str), 1, keyHash)
 
-			if respA.IsSetValue() && respB.IsSetValue() {
+			if respA != nil && respB != nil && respA.IsSetValue() && respB.IsSetValue() {
 				numHits += 2
 			}
 
@@ -480,8 +480,8 @@ func TestConsistentHashing(t *testing.T) {
 func queryKey(pool *HostConnectionPool, domain iface.Domain, t *testing.T, times int, numTries int32, expected string) int {
 	numHits := 0
 	for i := 0; i < times; i++ {
-		val := pool.Get(domain, Key1(), numTries, NO_HASH)
-		if val.IsSetValue() {
+		val, _ := pool.Get(domain, Key1(), numTries, NO_HASH)
+		if val != nil && val.IsSetValue() {
 			numHits++
 		}
 	}

--- a/hank_client/smart_client_test.go
+++ b/hank_client/smart_client_test.go
@@ -133,7 +133,7 @@ func TestIt(t *testing.T) {
 	setStateBlocking(t, host1, ctx, iface.HOST_UPDATING)
 	fixtures.WaitUntilOrFail(t, func() bool {
 		_, err := smartClient.Get(domain0.GetName(), []byte("key1"))
-		return reflect.DeepEqual(	"no connection available to domain "+domain0.GetName(), err.Error())
+		return reflect.DeepEqual("no connection available to domain "+domain0.GetName(), err.Error())
 	})
 
 	//	when offline, try anyway if it's the only replica

--- a/hank_client/smart_client_test.go
+++ b/hank_client/smart_client_test.go
@@ -125,14 +125,15 @@ func TestIt(t *testing.T) {
 		assert.Equal(t, value, string(val.Value))
 	}
 
-	fakeDomain, _ := smartClient.Get("fake", []byte("na"))
-	assert.True(t, reflect.DeepEqual(noSuchDomain(), fakeDomain))
+	_, err := smartClient.Get("fake", []byte("na"))
+
+	assert.Equal(t, "domain fake not found", err.Error())
 
 	//	no replicas live if updating
 	setStateBlocking(t, host1, ctx, iface.HOST_UPDATING)
 	fixtures.WaitUntilOrFail(t, func() bool {
-		updating, _ := smartClient.Get(domain0.GetName(), []byte("key1"))
-		return reflect.DeepEqual(NoConnectionAvailableResponse(), updating)
+		_, err := smartClient.Get(domain0.GetName(), []byte("key1"))
+		return reflect.DeepEqual(	"no connection available to domain "+domain0.GetName(), err.Error())
 	})
 
 	//	when offline, try anyway if it's the only replica

--- a/zk_coordinator/host.go
+++ b/zk_coordinator/host.go
@@ -14,7 +14,7 @@ import (
 	"github.com/LiveRamp/hank-go-client/iface"
 	"github.com/LiveRamp/hank-go-client/thriftext"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/pkg/errors"
 )
 
 const ASSIGNMENTS_PATH string = "a"
@@ -46,8 +46,7 @@ func CreateZkHost(ctx *thriftext.ThreadCtx, client curator.CuratorFramework, lis
 
 	node, err := curatorext.NewThriftWatchedNode(client, curator.PERSISTENT, rootPath, ctx, iface.NewHostMetadata, metadata)
 	if err != nil {
-		log.WithField("path", rootPath).WithError(err).Error("Error creating host node")
-		return nil, err
+		return nil, errors.Wrapf(err, "error creating host node, path: ", rootPath)
 	}
 
 	adapter := &thriftext.Adapter{Notifier: listener}
@@ -64,8 +63,7 @@ func CreateZkHost(ctx *thriftext.ThreadCtx, client curator.CuratorFramework, lis
 		iface.NewHostAssignmentMetadata,
 		assignmentMetadata)
 	if err != nil {
-		log.WithField("path", assignmentsRoot).WithError(err).Error("Error creating assignments node")
-		return nil, err
+		return nil, errors.Wrapf(err, "error creating assignments node, path: ", assignmentsRoot)
 	}
 
 	statePath := path.Join(rootPath, STATE_PATH)
@@ -76,8 +74,7 @@ func CreateZkHost(ctx *thriftext.ThreadCtx, client curator.CuratorFramework, lis
 	state.AddListener(adapter)
 
 	if err != nil {
-		log.WithField("path", statePath).WithError(err).Error("Error creating state node")
-		return nil, err
+		return nil, errors.Wrapf(err, "error creating state node.  path: %v", statePath)
 	}
 
 	return &ZkHost{rootPath, node, partitionAssignments, state, listener}, nil


### PR DESCRIPTION
Avoid error logging inside library where possible.  Return errors instead of errors inside hank Xception responses